### PR TITLE
Fix distributivity equivalence rule

### DIFF
--- a/src/main/java/proofcompiler/graph/Step.java
+++ b/src/main/java/proofcompiler/graph/Step.java
@@ -96,7 +96,7 @@ public abstract class Step implements Comparable<Step> {
                     )));
         equivCtrs.put("distributivity",     Equivalence.rule(List.of(
                         Equivalence.equ(and(p,  or(q, r)),  or(and(p, q), and(p, r))),
-                        Equivalence.equ( or(p, and(q, r)), and( or(p, q),  or(q, r)))
+                        Equivalence.equ( or(p, and(q, r)), and( or(p, q),  or(p, r)))
                     )));
         equivCtrs.put("absorption",         Equivalence.rule(List.of(
                         Equivalence.equ( or(p, and(p, q)), p),


### PR DESCRIPTION
It seems like there was a typo in the second part of it.

References:
![image](https://user-images.githubusercontent.com/8083858/79405369-116e4180-7f49-11ea-968d-f77d125d4df7.png)
https://courses.cs.washington.edu/courses/cse311/20sp/lectures/ref.html#/3